### PR TITLE
feat(workflow): add  ci workflow step to run screenshot tests [WD-26313]

### DIFF
--- a/.github/actions/setup-android/action.yaml
+++ b/.github/actions/setup-android/action.yaml
@@ -1,0 +1,21 @@
+  name: Setup Android Dependencies
+
+  runs:
+    using: composite
+    steps:
+    - name: Setup JDK
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+      with:
+        distribution: zulu
+        java-version: 21
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        cache-read-only: false
+    
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+      with:
+        cmdline-tools-version: latest
+        accept-android-sdk-licenses: true

--- a/.github/workflows/nia-ci.yaml
+++ b/.github/workflows/nia-ci.yaml
@@ -1,3 +1,5 @@
+name: Now in Android CI
+
 on:
   workflow_call:
 
@@ -6,10 +8,9 @@ permissions:
 
 jobs:
   lint-and-test:
-    name: Run Lint & Unit Tests
+    name: Run Lint, Unit Tests and Screenshot Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
     defaults:
       run:
         working-directory: ./nowinandroid
@@ -17,43 +18,45 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          distribution: zulu
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
-        with:
-          cache-read-only: false
+      
+      - name: Setup Android Dependencies
+        uses: ./.github/actions/setup-android
 
       - name: Run lint checks
         run: ./gradlew :app:lintDemoDebug
+
+      - name: Run unit tests
+        run: ./gradlew :app:testDemoDebugUnitTest
+
+      - name: Run screenshot tests
+        run: ./gradlew :app:compareRoborazziDemoDebug
 
       - name: Upload lint reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: lint-reports
+          name: nia-lint-reports
           path: '**/build/reports/lint-results-*.html'
 
-      - name: Run unit tests
-        run: ./gradlew :app:testDemoDebugUnitTest
-      - name: Upload test reports
+      - name: Upload unit test reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: unit-test-reports
+          name: nia-unit-test-reports
           path: '**/build/test-results/testDemoDebugUnitTest/*.xml'
+    
+      - name: Upload screenshot test reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: nia-screenshot-test-reports
+          path: '**/build/**/roborazzi/**'
 
   build-apk:
     name: Build Demo Debug APK
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: lint-and-test
-
     defaults:
       run:
         working-directory: ./nowinandroid
@@ -62,16 +65,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          distribution: zulu
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
-        with:
-          cache-read-only: false
+      - name: Setup Android Dependencies
+        uses: ./.github/actions/setup-android
 
       - name: Build Demo Debug APK
         run: ./gradlew :app:assembleDemoDebug
@@ -79,5 +74,5 @@ jobs:
       - name: Upload Demo Debug APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: nowinandroid-demo-debug-apk
+          name: nia-demo-debug-apk
           path: '**/build/outputs/apk/**/*.apk'

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@
 .PHONY: help
 help:
 	@echo "Available make targets for 'nowinandroid' :"
-	@echo "  nia-build - Build nowinandroid app"
-	@echo "  nia-install - Install nowinandroid app on connected device"
-	@echo "  nia-test - Test nowinandroid project"
-	@echo "  nia-clean - Clean build directory in nowinandroid project"
-	@echo "  nia-tasks - List available gradle tasks for nowinandroid project"
+	@echo "  nia-build - Build nia app"
+	@echo "  nia-install - Install nia app on connected device"
+	@echo "  nia-lint - Run lint checks on nia app"
+	@echo "  nia-unit-test - Run unit tests on nia app"
+	@echo "  nia-screenshot-test - Run screenshot tests on nia app"
+	@echo "  nia-clean - Clean build directory in nia app"
+	@echo "  nia-tasks - List available gradle tasks for nia app"
 
 
 .PHONY: nia-build
@@ -23,9 +25,13 @@ nia-install:
 nia-lint:
 	./nowinandroid/gradlew -p nowinandroid :app:lintDemoDebug
 
-.PHONY: nia-test
-nia-test:
+.PHONY: nia-unit-test
+nia-unit-test:
 	./nowinandroid/gradlew -p nowinandroid :app:testDemoDebugUnitTest
+
+.PHONY: nia-screenshot-test
+nia-screenshot-test:
+	./nowinandroid/gradlew -p nowinandroid :app:compareRoborazziDemoDebug
 
 .PHONY: nia-clean
 nia-clean:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A repository to showcase how Android applications can use the Anbox Cloud Applia
 
 It includes [nowinandroid](https://github.com/android/nowinandroid) (**'nia'** for short) as an example of a typical android project.
 
-- To add `nowinandroid` to anbox-cloud-demos repository as a subtree, run `git subtree add --prefix=nowinandroid https://github.com/android/nowinandroid.git main --squash`
+- To add `nowinandroid` to anbox-cloud-demos repository as a subtree, run `git subtree add --prefix=nowinandroid https://github.com/android/nowinandroid.git main --squash`.
 `
-- To pull latest changes from `nowinandroid` subtree, run `git subtree pull --prefix=nowinandroid https://github.com/android/nowinandroid.git main --squash`
+- To pull latest changes from `nowinandroid` subtree, run `git subtree pull --prefix=nowinandroid https://github.com/android/nowinandroid.git main --squash`.
 `
 ## Installation
 
-- Install [Android Studio](https://developer.android.com/studio) or VScode with all relevant dependencies and extensions, also make sure to add the following to your `~/.bashrc`
+- Install [Android Studio](https://developer.android.com/studio) or VScode with all relevant dependencies and extensions, also make sure to add the following to your `~/.bashrc`.
 
 ```
 export PATH="~$PATH:~/Android/Sdk/platform-tools"
@@ -23,37 +23,30 @@ export PATH=$ANDROID_HOME/platform-tools:$PATH
 ## Development
 
 - Clone the repository and open the root directory in Android Studio or VScode.
-- Run `make nia-build | nia-install` to buil and generate nia app apk or install the apk - as 'DemoDebug' flavor - directly on the connected device.
+- Run `make nia-build | nia-install` to buil and generate nia apk or install the apk - as 'DemoDebug' flavor - directly on the connected device.
 - For more options you can run `make help` which will show all available make targets and commands.
 - Make sure to connect an android device with `adb connect`, by following this guide on how to [Access an Android instance](https://documentation.ubuntu.com/anbox-cloud/howto/android/access-android-instance/#access-the-android-instance-using-anbox-connect) running in Anbox.
 
  
 ## Testing
 
-- Write integration test/screenshot tests or use existing tests from `nowinandroid`
+- Run `make nia-ui-test` and `make nia-screenshot-test`
+- This will generate test `outputs`, `reports` and `test-results` in `app/build/` directory.   
 
 ## GitHub Workflow
 
-- Create a PR in GitHub with committed changes in any UI element
-- This will trigger `nia-pr.yaml` workflow that will:
-```
-    1- Install JDK and Gradle dependencies
+- Create a PR in GitHub with committed changes in any UI element.
+- This will trigger `./workflows/nia-pr.yaml` workflow that uses:
 
-    2- Run lint checks and unit tests
-
-    3- Build the Demo APK
-
-    4- Install the Anbox Cloud Appliance w/ runner (w/o AWS)
-
-     a- Connect to the remote AMS
-
-     b- Spin up a new instance
-
-     c- Connect ADB link
-
-     d- Run UI screenshot tests
-
-     e- Link to Deployment / APK and Test Report
-```
-`
-     
+    1- `./workflows/nia-ci.yaml`:
+    
+    - Runs `ubuntu-latest` on GitHub hosted runner.
+    
+    - Runs `./actions/setup-android/action.yaml` to install JDK, Gradle and Android SDK dependencies.
+    
+    - Runs lint checks, unit tests and roborazzi screenshot tests.
+    
+    - Builds the Demo APK.
+    
+    - Uploads the lint, unit test and screenshot test reports, as well as the demo APK as artifacts.
+    


### PR DESCRIPTION
## Done
- This PR is to add to the lint-and-test job a step to run screenshot tests using roborazzi and create a comparison report, downloadable from the artifacts.

- Makefile, and readme are modified to reflect the added screenshot test command.

- The JDK, SDK and Gradle installation steps are also moved to a reusable action instead of code duplication in each job.

## QA

Perform the following QA steps:
- Create a branch and PR which will trigger the nia-pr.yaml workflow and checks will run automatically or re-run the actions from 'Checks' tab.
- The output artifact should include screenshot test report
- Locally you can run the same steps using `make nia-screenshot-test` and check the `app/build/** folders`

## JIRA / Launchpad bug

Fixes # [Anbox Cloud Demo - Add pr ci workflow step to run screenshot tests](https://warthogs.atlassian.net/browse/WD-26313)

## Documentation
- README updated 

## Screenshots
<img width="1536" height="366" alt="Screenshot from 2025-09-11 21-27-25" src="https://github.com/user-attachments/assets/af70eab9-df35-49dd-a743-420ce9180841" />

