### PR TITLE
feat(workflow): add e2e workflow steps to run tests on remote amc hosted on AWS [WD-26499]

### DIFF
--- a/.github/workflows/nia-e2e.yaml
+++ b/.github/workflows/nia-e2e.yaml
@@ -2,7 +2,7 @@ name: Now in Android E2E
 
 on:
   workflow_call:
-  
+
 permissions:
   contents: read
 
@@ -13,15 +13,14 @@ jobs:
     env:
         ANDROID_VERSION: "15"
     timeout-minutes: 60
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
     - name: Setup Anbox Cloud
       uses: canonical/anbox-cloud-github-action@dc99b94280cfcf44a86b62aeac25ba34f14725e0
       with:
-        channel: 1.28/edge/amc-connect
+        channel: 1.28/edge
 
     - name: Tune Anbox Cloud
       run: |
@@ -31,54 +30,65 @@ jobs:
       env:
         REMOTE_AMC_URL: ${{ vars.REMOTE_AMC_URL }}
         REMOTE_SERVER_CERT: ${{ secrets.REMOTE_SERVER_CERT }}
-        REMOTE_CLIENT_CERT: ${{ secrets.REMOTE_CLIENT_CERT }}
-        REMOTE_CLIENT_KEY: ${{ secrets.REMOTE_CLIENT_KEY }}
+        GH_RUNNER_CERT: ${{ secrets.GH_RUNNER_CERT }}
+        GH_RUNNER_KEY: ${{ secrets.GH_RUNNER_KEY }}
       run: |
-        set -x
-
-        dir="$HOME/snap/anbox-cloud-appliance/current/client"
         url=${REMOTE_AMC_URL}
         if [ -z "${url}" ]; then
-            url="https://$(amc config show | grep -Po 'core\.https_address:\s*\K.*')"
-            amc config trust add "${dir}/client.crt"
+          url="https://$(amc config show | grep -Po 'core\.https_address:\s*\K.*')"
         fi
 
-        if [[ -n "${REMOTE_CLIENT_CERT}" && -n "${REMOTE_CLIENT_KEY}" ]]; then
-          pem="${REMOTE_CLIENT_CERT}"$'\n'"${REMOTE_CLIENT_KEY}"
-          echo "${pem}" | amc auth identity create tls/test-user -
+        amc_state_dir="$HOME"/snap/anbox-cloud-appliance/current/client
+        if [ -n "${GH_RUNNER_CERT}" ] && [ -n "${GH_RUNNER_KEY}" ]; then
+          echo "${GH_RUNNER_CERT}" > "$amc_state_dir"/client.crt
+          echo "${GH_RUNNER_KEY}" > "$amc_state_dir"/client.key
         fi
+        amc auth identity create tls/test-user - < \
+        "$amc_state_dir"/client.crt
 
+        mkdir -p "$amc_state_dir"/servercerts
+        server_crt_path="$amc_state_dir"/servercerts/server.crt
         if [ -n "${REMOTE_SERVER_CERT}" ]; then
-          mkdir -p "${dir}/servercerts"
-          echo "$REMOTE_SERVER_CERT" > ${dir}/servercerts/server.crt
+          echo "${REMOTE_SERVER_CERT}" > "$server_crt_path"
+        else
+          # We use cat to write the file with the current users ownership
+          sudo cat /var/snap/anbox-cloud-appliance/common/ams/server/ams.crt > \
+            "$server_crt_path"
         fi
 
-        amc remote add --accept-certificate server "${url}"
+        # FIXME: workaround lp#2129004. Once fixed we can switch back to
+        # amc remote add server "${url}"
+        cat << EOF >> "$amc_state_dir"/settings.yaml
+          server:
+            url: "${url}"
+            auth-type: tls
+        EOF
+
         amc remote set-default server
 
     - name: Restore cached images
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      if: ${{ !vars.REMOTE_AMC_URL }}
       with:
         path: images
         key: anbox-images-amd64
         fail-on-cache-miss: true
-  
+
     - name: Import cached images
+      if: ${{ !vars.REMOTE_AMC_URL }}
       run: |
         amc image add jammy:android${ANDROID_VERSION}:amd64 ./images/android${ANDROID_VERSION}.tar.xz
 
     - name: Create android instance
       id: create-instance
       run: |
-        sudo snap restart anbox-cloud-appliance.ams
-        sleep 30
         id="$(amc launch --enable-streaming jammy:android${ANDROID_VERSION}:amd64)"
         amc wait -c status=running "$id"
         echo "id=$id" >> "$GITHUB_OUTPUT"
 
     - name: Connect over adb
       run: |
-        set -x
+        sudo apt install -y adb
 
         id=${{ steps.create-instance.outputs.id }}
         rm -fr logs && mkdir -p logs
@@ -93,9 +103,9 @@ jobs:
           done
           return 1
         }
-        
+
         wait_for_adb_connect
-        url=$(grep -oP 'adb connect\s*\K.*' logs/anbox-connect.log)                  
+        url=$(grep -oP 'adb connect\s*\K.*' logs/anbox-connect.log)
         adb connect "${url}"
 
     - name: Run e2e tests
@@ -109,11 +119,38 @@ jobs:
       with:
         name: nia-e2e-test-reports
         path: '**/build/reports/androidTests/**'
-        
+
+    - name: Dump logs
+      if: failure()
+      run: |
+        id=${{ steps.create-instance.outputs.id }}
+        sudo snap logs -n all anbox-cloud-appliance > appliance.log
+        sudo anbox-cloud-appliance.buginfo > appliance.buginfo
+        status=$(amc show "$id" --format=json | jq -r .status)
+        if [ "$status" = error ] ; then
+          for log in $(amc show "$id" --format=json | jq -r '.stored_logs[]' | xargs) ; do
+            amc show-log "$id" "$log" |& tee -a "$id"_"$log"
+          done
+        elif [ "$status" = started ] || [ "$status" = running ]; then
+          for name in android anbox ; do
+            timeout 30s amc logs "$id" -t "$name" |& tee -a "$id"_"$name".log
+          done
+        fi
+
+    - name: Upload Logs
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      if: failure()
+      with:
+        name: logs-dump-${{ github.run_id }}
+        path: |
+                appliance.buginfo
+                *.log
+        retention-days: 30
+
     - name: Clean up android instance
       if: always()
       run: |
         id=${{ steps.create-instance.outputs.id }}
-        amc delete -y "$id"
-      
-       
+        if [ -n "$id" ]; then
+          amc delete -y "$id"
+        fi

--- a/.github/workflows/nia-e2e.yaml
+++ b/.github/workflows/nia-e2e.yaml
@@ -1,4 +1,4 @@
-name: Now in Android CI
+name: Now in Android E2E
 
 on:
   workflow_call:
@@ -21,18 +21,48 @@ jobs:
     - name: Setup Anbox Cloud
       uses: canonical/anbox-cloud-github-action@dc99b94280cfcf44a86b62aeac25ba34f14725e0
       with:
-        channel: latest/stable
+        channel: 1.28/edge/amc-connect
 
     - name: Tune Anbox Cloud
       run: |
         amc config set container.security_updates false
+
+    - name: Setup remote amc
+      env:
+        REMOTE_AMC_URL: ${{ vars.REMOTE_AMC_URL }}
+        REMOTE_SERVER_CERT: ${{ secrets.REMOTE_SERVER_CERT }}
+        REMOTE_CLIENT_CERT: ${{ secrets.REMOTE_CLIENT_CERT }}
+        REMOTE_CLIENT_KEY: ${{ secrets.REMOTE_CLIENT_KEY }}
+      run: |
+        set -x
+
+        dir="$HOME/snap/anbox-cloud-appliance/current/client"
+        url=${REMOTE_AMC_URL}
+        if [ -z "${url}" ]; then
+            url="https://$(amc config show | grep -Po 'core\.https_address:\s*\K.*')"
+            amc config trust add "${dir}/client.crt"
+        fi
+
+        if [[ -n "${REMOTE_CLIENT_CERT}" && -n "${REMOTE_CLIENT_KEY}" ]]; then
+          pem="${REMOTE_CLIENT_CERT}"$'\n'"${REMOTE_CLIENT_KEY}"
+          echo "${pem}" | amc auth identity create tls/test-user -
+        fi
+
+        if [ -n "${REMOTE_SERVER_CERT}" ]; then
+          mkdir -p "${dir}/servercerts"
+          echo "$REMOTE_SERVER_CERT" > ${dir}/servercerts/server.crt
+        fi
+
+        amc remote add --accept-certificate server "${url}"
+        amc remote set-default server
 
     - name: Restore cached images
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: images
         key: anbox-images-amd64
-
+        fail-on-cache-miss: true
+  
     - name: Import cached images
       run: |
         amc image add jammy:android${ANDROID_VERSION}:amd64 ./images/android${ANDROID_VERSION}.tar.xz
@@ -40,21 +70,38 @@ jobs:
     - name: Create android instance
       id: create-instance
       run: |
-        id="$(amc launch -r -s adb jammy:android${ANDROID_VERSION}:amd64)"
+        sudo snap restart anbox-cloud-appliance.ams
+        sleep 30
+        id="$(amc launch --enable-streaming jammy:android${ANDROID_VERSION}:amd64)"
         amc wait -c status=running "$id"
         echo "id=$id" >> "$GITHUB_OUTPUT"
 
-    - name: Access android over adb
+    - name: Connect over adb
       run: |
-        sudo apt install -y adb
+        set -x
+
         id=${{ steps.create-instance.outputs.id }}
-        addr="$(amc show "$id" --format=json | jq -r .network.address)"
-        adb connect "$addr":5559
-        test "$(adb shell getprop ro.product.model)" = Anbox
+        rm -fr logs && mkdir -p logs
+        amc connect -k "$id" |& tee logs/anbox-connect.log &
+
+        wait_for_adb_connect() {
+          for i in {1..5}; do
+            if grep "adb connect 127.0.0.1" logs/anbox-connect.log; then
+              return 0
+            fi
+            sleep 5
+          done
+          return 1
+        }
+        
+        wait_for_adb_connect
+        url=$(grep -oP 'adb connect\s*\K.*' logs/anbox-connect.log)                  
+        adb connect "${url}"
 
     - name: Run e2e tests
-      run: ./gradlew :app:connectedDemoDebugAndroidTest
       working-directory: ./nowinandroid
+      run: |
+        ./gradlew :app:connectedDemoDebugAndroidTest
 
     - name: Upload e2e test reports
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -62,3 +109,11 @@ jobs:
       with:
         name: nia-e2e-test-reports
         path: '**/build/reports/androidTests/**'
+        
+    - name: Clean up android instance
+      if: always()
+      run: |
+        id=${{ steps.create-instance.outputs.id }}
+        amc delete -y "$id"
+      
+       

--- a/.github/workflows/nia-pr.yaml
+++ b/.github/workflows/nia-pr.yaml
@@ -13,11 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nia-ci:
-    uses: ./.github/workflows/nia-ci.yaml
-    secrets: inherit
+  # nia-ci:
+  #   uses: ./.github/workflows/nia-ci.yaml
+  #   secrets: inherit
   
   nia-e2e:
-    needs: nia-ci
+    # needs: nia-ci
     uses: ./.github/workflows/nia-e2e.yaml
     secrets: inherit

--- a/.github/workflows/nia-pr.yaml
+++ b/.github/workflows/nia-pr.yaml
@@ -13,11 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # nia-ci:
-  #   uses: ./.github/workflows/nia-ci.yaml
-  #   secrets: inherit
-  
+  nia-ci:
+    uses: ./.github/workflows/nia-ci.yaml
+    secrets: inherit
+
   nia-e2e:
-    # needs: nia-ci
+    needs: nia-ci
     uses: ./.github/workflows/nia-e2e.yaml
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export PATH=$ANDROID_HOME/platform-tools:$PATH
     
     - Restores cached Android image, launch it and connects the instance with ADB.
 
-    - Run E2E tests (Equivalent to running make nia-e2e-test)
+    - Runs E2E tests (Equivalent to running make nia-e2e-test)
 
     - Uploads the e2e test report to the artifacts
     
@@ -61,8 +61,8 @@ export PATH=$ANDROID_HOME/platform-tools:$PATH
 **Notes**
 - Another workflow is `cache-images.yaml` to download and cache Android images, that is scheduled to run every day at 10:00 AM, or can manually be dispatched.
 
-- To add a remote amc where you launch the Android image, and connect to adb for running e2e tests, you must provide the following in the repos secrets: otherwise the runner's internal ip will be used as the remote url.
-1. `REMOTE_AMC_URL`: in this format `https://<remote-amc-ip>:8444`
-2. `REMOTE_CLIENT_CERT`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.crt`
-3. `REMOTE_CLIENT_KEY`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.key`
-in the repos secrets;
+- To add a remote amc where you launch the Android image, and connect to adb for running e2e tests, you must provide the following in the repos variables and secrets: otherwise the runner's internal ip will be used as the remote url.
+1. `vars.REMOTE_AMC_URL `: in this format `https://<remote-amc-ip>:8444`
+2. `secrets.REMOTE_SERVER_CERT`: content found in `/var/snap/anbox-cloud-appliance/common/ams/server/ams.crt`
+3. `secrets.GH_RUNNER_CERT`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.crt`
+4. `secrets.GH_RUNNER_KEY`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.key`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repository to showcase how Android applications can use the Anbox Cloud Appliance for local development, and to demo how it can be used as part of GitHub workflows for running UI screenshot tests and generating test reports.
 
-It includes [nowinandroid](https://github.com/android/nowinandroid) (**'nia'** for short) as an example of a typical android project.
+It includes [nowinandroid](https://github.com/android/nowinandroid) (**'nia'** for short) as an example of a typical Android project.
 
 - To add `nowinandroid` to anbox-cloud-demos repository as a subtree, run `git subtree add --prefix=nowinandroid https://github.com/android/nowinandroid.git main --squash`.
 `
@@ -25,7 +25,7 @@ export PATH=$ANDROID_HOME/platform-tools:$PATH
 - Clone the repository and open the root directory in Android Studio or VScode.
 - Run `make nia-build | nia-install` to buil and generate nia apk or install the apk - as 'DemoDebug' flavor - directly on the connected device.
 - For more options you can run `make help` which will show all available make targets and commands.
-- Make sure to connect an android device with `adb connect`, by following this guide on how to [Access an Android instance](https://documentation.ubuntu.com/anbox-cloud/howto/android/access-android-instance/#access-the-android-instance-using-anbox-connect) running in Anbox.
+- Make sure to connect an Android device with `adb connect`, by following this guide on how to [Access an Android instance](https://documentation.ubuntu.com/anbox-cloud/howto/android/access-android-instance/#access-the-android-instance-using-anbox-connect) running in Anbox.
 
  
 ## Testing
@@ -48,10 +48,21 @@ export PATH=$ANDROID_HOME/platform-tools:$PATH
     
 2. And `./workflows/nia-e2e.yaml`:
  
-    - Runs `canonical/anbox-cloud-github-action` to install LXD and the Anbox Cloud Appliance [skipped if self-hosted].
+    - Runs `canonical/anbox-cloud-github-action` to install LXD and the Anbox Cloud Appliance.
     
     - Restores cached Android image, launch it and connects the instance with ADB.
 
     - Run E2E tests (Equivalent to running make nia-e2e-test)
 
+    - Uploads the e2e test report to the artifacts
+    
+    - Cleans up the created Android instance after finishing all tests
+
+**Notes**
 - Another workflow is `cache-images.yaml` to download and cache Android images, that is scheduled to run every day at 10:00 AM, or can manually be dispatched.
+
+- To add a remote amc where you launch the Android image, and connect to adb for running e2e tests, you must provide the following in the repos secrets: otherwise the runner's internal ip will be used as the remote url.
+1. `REMOTE_AMC_URL`: in this format `https://<remote-amc-ip>:8444`
+2. `REMOTE_CLIENT_CERT`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.crt`
+3. `REMOTE_CLIENT_KEY`: content found in `$HOME"/snap/anbox-cloud-appliance/current/client/client.key`
+in the repos secrets;


### PR DESCRIPTION
## Done
This PR implements additional steps in `nia-e2e.yaml` to run e2e tests using `amc connect` on a remote `amc` hosted on AWS.

### Steps: ###
 **1.  "Setup remote amc"** 
- if remote url and certificates are provided in the repo secrets, amc remote url will be added and cert trusted
- remote url (if provided) must be public and in this format `https://<remote-amc-ip>:8444`
- if remote url is not provided, the github runner host ip will be used instead
- the remote amc is set as default

**2. "Create Android Instance"**
- launches an android instance with streaming enabled
- outputs instance id for the following steps
 
**3."Connect over adb"**
- runs `amc connect` command to create a sharing link and initiate adb connection
- `amc connect` is a wrapper for `anbox-connect` and is ONLY available on `snap install anbox-cloud-appliance --channel=1.28/edge/amc-connect` or above
-  Once the adb link (IP & PORT) is generated, `adb connect 127.0.0.1:$PORT` is called to attach device 

**4."Run e2e tests"**
- execute the `./gradlew :app:connectedDemoDebugAndroidTest` command.

**5."Upload e2e test reports"**
- uploads the e2e report to the artifacts

**6."Clean up android instance"**
- deletes the android instance after completing the tests

## QA
1. Perform the following QA steps:
 - submit a PR to trigger `nia-pr.yaml` workflow in which the e2e job will perform the installation of anbox appliance, launch android instance, connect adb and run the e2e test
 - All checks should pass as shown in the screenshots below
 - An artifact "nia-e2e-test" should be available
 
2. You can repeat the steps but this time make sure before you do, that the `REMOTE_AMC_URL`, `REMOTE_SERVER_CERT`, `GH_RUNNER_CERT` and `GH_RUNNER_KEY` are added to the repo; otherwise the runner's internal ip will be used as the remote amc.
- GH_RUNNER cert should be trusted on the remote aws instance
- again follow the same steps as (# 1) but this time the instance will run on the remote amc provided
- steps should pass and produce the report artifact

## JIRA / Launchpad bug

Fixes # [Anbox Cloud Demo - Add workflow steps to run e2e tests on remote amc hosted on AWS](https://warthogs.atlassian.net/browse/WD-26499)
[Update anbox-cloud-appliance snap to 1.28/edge](https://warthogs.atlassian.net/browse/WD-29854)

## Documentation
- README includes updated steps to run in github hosted runner and attach a remote amc client

## Screenshots
**Android instance creation on remote ams in realtime with the runner**

[![Watch the video](https://github.com/user-attachments/assets/cc07f662-7eb7-4c61-b38c-bec371428dec)](https://github.com/user-attachments/assets/cc07f662-7eb7-4c61-b38c-bec371428dec)

**CI and e2e Jobs completing successfully**
<img width="1920" height="719" alt="Screenshot from 2025-10-10 19-10-17" src="https://github.com/user-attachments/assets/1ccf07e4-50a7-474f-8e83-685e8b669c68" />

**e2e test report downloadable from artifacts**
<img width="1901" height="914" alt="Screenshot from 2025-10-10 19-10-52" src="https://github.com/user-attachments/assets/1f3be009-3814-421f-9659-f71741c76919" />

**e2e test report output**
<img width="874" height="755" alt="Screenshot from 2025-10-10 19-41-05" src="https://github.com/user-attachments/assets/6bdc70ae-5068-4abc-8e34-c0715bf3a413" />
